### PR TITLE
Additional work on the header

### DIFF
--- a/Base/BaseLinkDef.h
+++ b/Base/BaseLinkDef.h
@@ -7,6 +7,5 @@
 
 #pragma link C++ class AliceO2::Base::Detector+;
 #pragma link C++ class AliceO2::Base::TrackReference+;
-#pragma link C++ struct AliceO2::Base::DataHeader+;
 
 #endif

--- a/Base/CMakeLists.txt
+++ b/Base/CMakeLists.txt
@@ -26,7 +26,10 @@ TrackReference.cxx
 DataHeader.cxx
 )
 
-Set(HEADERS)
+Set(HEADERS
+Detector.h
+TrackReference.h
+)
 Set(LINKDEF BaseLinkDef.h)
 Set(LIBRARY_NAME AliceO2Base)
 Set(DEPENDENCIES Base EG Physics Core)

--- a/Base/DataHeader.cxx
+++ b/Base/DataHeader.cxx
@@ -1,4 +1,6 @@
 #include "DataHeader.h"
+#include <cstdio> // printf
+#include <cstring> // strncpy
 
 const char* AliceO2::Base::DataHeader::sMagicString = "O2 ";
 
@@ -61,7 +63,7 @@ void AliceO2::Base::DataHeader::print() const
   printf("  origin       : %s\n", dataOrigin);
   printf("  serialization: %s\n", payloadSerialization);
   printf("  description  : %s\n", dataDescription);
-  printf("  sub spec.    : %lli\n", subSpecification);
+  printf("  sub spec.    : %lu\n", subSpecification);
   printf("  header size  : %i\n", headerSize);
   printf("  payloadSize  : %i\n", payloadSize);
 }
@@ -132,4 +134,109 @@ bool AliceO2::Base::DataHeader::operator==(const DataHeader& that)
           dataOriginInt == that.dataOriginInt &&
           dataDescriptionInt == that.dataDescriptionInt &&
           subSpecification == that.subSpecification );
+}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::DataOrigin::DataOrigin() : dataOriginInt(gInvalidToken32) {}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::DataOrigin::DataOrigin(const char* origin)
+  : dataOriginInt(gInvalidToken32)
+{
+  if (origin) {
+    strncpy(dataOrigin, origin, gSizeDataOriginString-1);
+  }
+}
+
+//_________________________________________________________________________________________________
+bool AliceO2::Base::DataOrigin::operator==(const AliceO2::Base::DataOrigin& other) const
+{
+  return dataOriginInt == other.dataOriginInt;
+}
+
+//_________________________________________________________________________________________________
+void AliceO2::Base::DataOrigin::print() const
+{
+  printf("Data origin  : %s\n", dataOrigin);
+}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::DataDescription::DataDescription()
+  : dataDescriptionInt()
+{
+  dataDescriptionInt[0] = gInvalidToken64;
+  dataDescriptionInt[1] = gInvalidToken64<<8 | gInvalidToken64;
+}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::DataDescription::DataDescription(const char* desc)
+  : dataDescription()
+{
+  *this = DataDescription(); // initialize by standard constructor
+  if (desc) {
+    strncpy(dataDescription, desc, gSizeDataDescriptionString-1);
+  }
+}
+
+//_________________________________________________________________________________________________
+bool AliceO2::Base::DataDescription::operator==(const AliceO2::Base::DataDescription& other) const {
+  return (dataDescriptionInt[0] == other.dataDescriptionInt[0] &&
+          dataDescriptionInt[1] == other.dataDescriptionInt[1]);
+}
+
+//_________________________________________________________________________________________________
+void AliceO2::Base::DataDescription::print() const
+{
+  printf("Data descr.  : %s\n", dataDescription);
+}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::DataIdentifier::DataIdentifier()
+  : dataDescription(), dataOrigin()
+{
+}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::DataIdentifier::DataIdentifier(const char* desc, const char* origin)
+  : dataDescription(), dataOrigin()
+{
+  dataDescription = AliceO2::Base::DataDescription(desc);
+  dataOrigin = AliceO2::Base::DataOrigin(origin);
+}
+
+//_________________________________________________________________________________________________
+bool AliceO2::Base::DataIdentifier::operator==(const AliceO2::Base::DataIdentifier& other) const {
+  if (other.dataOrigin != gDataOriginAny && dataOrigin != other.dataOrigin) return false;
+  if (other.dataDescription != gDataDescriptionAny && dataDescription != other.dataDescription) return false;
+  return true;
+}
+
+//_________________________________________________________________________________________________
+void AliceO2::Base::DataIdentifier::print() const
+{
+  dataOrigin.print();
+  dataDescription.print();
+}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::PayloadSerialization::PayloadSerialization() : payloadSerializationInt(gInvalidToken64) {}
+
+//_________________________________________________________________________________________________
+AliceO2::Base::PayloadSerialization::PayloadSerialization(const char* serialization)
+  : payloadSerializationInt(gInvalidToken32)
+{
+  if (serialization) {
+    strncpy(payloadSerialization, serialization, gSizePayloadSerializationString-1);
+  }
+}
+
+//_________________________________________________________________________________________________
+bool AliceO2::Base::PayloadSerialization::operator==(const AliceO2::Base::PayloadSerialization& other) const {
+  return payloadSerializationInt == other.payloadSerializationInt;
+}
+
+//_________________________________________________________________________________________________
+void AliceO2::Base::PayloadSerialization::print() const
+{
+  printf("Serialization: %s\n", payloadSerialization);
 }

--- a/Base/DataHeader.h
+++ b/Base/DataHeader.h
@@ -8,8 +8,6 @@
 #define ALICEO2_BASE_DATA_HEADER_
 
 #include <cstdint>
-#include <cstring>
-#include <cstdio>
 
 namespace AliceO2 {
 namespace Base {
@@ -23,6 +21,7 @@ const uint32_t gSizeDataDescriptionString = 16;
 struct DataHeader;
 struct DataOrigin;
 struct DataDescription;
+struct DataIdentifier;
 struct PayloadSerialization;
 
 //____________________________________________________________________________
@@ -94,16 +93,18 @@ struct DataOrigin
     char     dataOrigin[gSizeDataOriginString];
     uint32_t  dataOriginInt;
   };
-  DataOrigin(const char* origin)
-    //: dataOriginInt(*(reinterpret_cast<const uint32_t*>(origin))) {}
-    : dataOrigin() {
-      memset(dataOrigin, ' ', gSizeDataOriginString-1);
-      if (origin) {
-        strncpy(dataOrigin, origin, gSizeDataOriginString-1);
-      }
-      dataOrigin[gSizeDataOriginString-1] = '\0';
-    }
-  void print() const {printf("Data origin  : %s\n", dataOrigin);}
+  DataOrigin();
+  DataOrigin(const DataOrigin& other) : dataOriginInt(other.dataOriginInt) {}
+  DataOrigin& operator=(const DataOrigin& other) {
+    if (&other != this) dataOriginInt = other.dataOriginInt;
+    return *this;
+  }
+  // note: no operator=(const char*) as this potentially runs into trouble with this
+  // general pointer type, use: someorigin = DataOrigin("BLA")
+  DataOrigin(const char* origin);
+  bool operator==(const DataOrigin&) const;
+  bool operator!=(const DataOrigin& other) const {return not this->operator==(other);}
+  void print() const;
 };
 
 //____________________________________________________________________________
@@ -114,18 +115,34 @@ struct DataDescription
     char     dataDescription[gSizeDataDescriptionString];
     uint64_t  dataDescriptionInt[2];
   };
-  DataDescription(const char* desc)
-    //: dataDescriptionInt { (reinterpret_cast<const uint64_t*>(desc))[0],
-    //                       (reinterpret_cast<const uint64_t*>(desc))[1]
-    //                     }  {}
-    : dataDescription() {
-      memset(dataDescription, ' ', gSizeDataDescriptionString-1);
-      if (desc) {
-        strncpy(dataDescription, desc, gSizeDataDescriptionString-1);
-      }
-      dataDescription[gSizeDataDescriptionString-1] = '\0';
+  DataDescription();
+  DataDescription(const DataDescription& other) : dataDescriptionInt() {*this = other;}
+  DataDescription& operator=(const DataDescription& other) {
+    if (&other != this) {
+      dataDescriptionInt[0] = other.dataDescriptionInt[0];
+      dataDescriptionInt[1] = other.dataDescriptionInt[1];
     }
-  void print() const {printf("Data descr.  : %s\n", dataDescription);}
+    return *this;
+  }
+  // note: no operator=(const char*) as this potentially runs into trouble with this
+  // general pointer type, use: somedesc = DataOrigin("SOMEDESCRIPTION")
+  DataDescription(const char* desc);
+  bool operator==(const DataDescription&) const;
+  bool operator!=(const DataDescription& other) const {return not this->operator==(other);}
+  void print() const;
+};
+
+//____________________________________________________________________________
+struct DataIdentifier
+{
+  //a full data identifier combining origin and description
+  DataDescription dataDescription;
+  DataOrigin dataOrigin;
+  DataIdentifier();
+  DataIdentifier(const DataIdentifier&);
+  DataIdentifier(const char* desc, const char* origin);
+  bool operator==(const DataIdentifier&) const;
+  void print() const;
 };
 
 //____________________________________________________________________________
@@ -136,17 +153,19 @@ struct PayloadSerialization
     char     payloadSerialization[gSizePayloadSerializationString];
     uint64_t  payloadSerializationInt;
   };
-  PayloadSerialization(const char* serialization)
-    //: payloadSerializationInt(*(reinterpret_cast<const uint64_t*>(serialization))) {}
-    : payloadSerialization() {
-      memset(payloadSerialization, ' ', gSizePayloadSerializationString-1);
-      if (serialization) {
-        strncpy(payloadSerialization, serialization, gSizePayloadSerializationString-1);
-      }
-      payloadSerialization[gSizePayloadSerializationString-1] = '\0';
-    }
-  void print() const {printf("Serialization: %s\n", payloadSerialization);}
+  PayloadSerialization();
+  // note: no operator=(const char*) as this potentially runs into trouble with this
+  // general pointer type, use: sertype = DataOrigin("SERTYPE")
+  PayloadSerialization(const char* serialization);
+  bool operator==(const PayloadSerialization&) const;
+  void print() const;
 };
+
+//____________________________________________________________________________
+//default int representation of 'invalid' token for char fields
+//TODO: endiness adaption at compile time
+const uint32_t gInvalidToken32 = 0x00202020;
+const uint64_t gInvalidToken64 = 0x0020202020202020;
 
 //____________________________________________________________________________
 //possible data origins


### PR DESCRIPTION
I thought it might be useful to further discuss our development directly on github so have it for the record. We can close the PR and I add further things after the discussion if necessary.

I have temporarily removed the ROOT dictionary generation for the DataHeader_t, because I had problems to compile it. Surely related to ROOT 5 but I do not want to update now. Time is better spent on coding.

In principle I would like to keep the header file as simple as possible. So I moved all code requiring additional includes to the cxx. I have implemented a few more operators and initializers for the helper structs. I also added DataIdentifier combining Origin and Description.

As an idea we might even move the operators to a separate tool implementation file.

My next work is to set up a unit test for all those operators, some things can even be done at compile time.

Cheers
Matthias
